### PR TITLE
Integrate add-to-calendar library

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <!-- Tu archivo CSS personalizado -->
     <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/add-to-calendar-button@1/assets/css/atcb.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/add-to-calendar-button@2/assets/css/atcb.min.css">
     <meta name="theme-color" content="#007bff">
     <!-- Favicons -->
     <link rel="icon" href="images/icons/favicon.ico" sizes="any" type="image/x-icon">
@@ -574,7 +574,9 @@
                                 </div>
                                 <!-- Botones de acción -->
                                 <div class="d-grid gap-2">
-                                    <div id="addToCalendarBtn" class="atcb" style="display:none;"></div>
+                                    <button class="btn btn-success" id="addToCalendarBtn">
+                                        <i class="fas fa-calendar-plus"></i> Añadir al calendario
+                                    </button>
                                     <button class="btn btn-primary" id="getDirectionsBtn"><i class="fas fa-directions"></i> Cómo llegar</button>
                                     <button class="btn btn-secondary" id="shareEventBtn"><i class="fas fa-share-alt"></i> Compartir</button>
                                 </div>
@@ -758,7 +760,7 @@
     <!-- Tu script.js -->
     <script src="script.js"></script>
     <!-- Add to Calendar Button library -->
-    <script src="https://cdn.jsdelivr.net/npm/add-to-calendar-button@1" async defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/add-to-calendar-button@2" async defer></script>
     <!-- Archivo de provincias.js si es necesario -->
     <script src="provincias.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <!-- Tu archivo CSS personalizado -->
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/add-to-calendar-button@1/assets/css/atcb.min.css">
     <meta name="theme-color" content="#007bff">
     <!-- Favicons -->
     <link rel="icon" href="images/icons/favicon.ico" sizes="any" type="image/x-icon">
@@ -573,7 +574,7 @@
                                 </div>
                                 <!-- Botones de acción -->
                                 <div class="d-grid gap-2">
-                                    <button class="btn btn-success" id="addToCalendarBtn"><i class="fas fa-calendar-plus"></i> Añadir al calendario</button>
+                                    <div id="addToCalendarBtn" class="atcb" style="display:none;"></div>
                                     <button class="btn btn-primary" id="getDirectionsBtn"><i class="fas fa-directions"></i> Cómo llegar</button>
                                     <button class="btn btn-secondary" id="shareEventBtn"><i class="fas fa-share-alt"></i> Compartir</button>
                                 </div>
@@ -756,6 +757,8 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Tu script.js -->
     <script src="script.js"></script>
+    <!-- Add to Calendar Button library -->
+    <script src="https://cdn.jsdelivr.net/npm/add-to-calendar-button@1" async defer></script>
     <!-- Archivo de provincias.js si es necesario -->
     <script src="provincias.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -315,6 +315,10 @@ function isAllDayEvent(startTime, endTime) {
     return (startTime === "00:00" && endTime === "23:59");
 }
 
+function datePart(dateString) {
+    return dateString ? dateString.split(' ')[0] : '';
+}
+
 function formatDateToUTC(dateString) {
     const date = new Date(dateString);
     const year = date.getUTCFullYear();
@@ -776,13 +780,34 @@ function showEventDetails(event) {
         document.getElementById('adminButtons').classList.add('d-none');
     }
 
-    // Preparar botones de acción
-    document.getElementById('addToCalendarBtn').onclick = function() {
-        const currentEvent = event; // Capturamos el objeto event
+    // Preparar botón "Añadir al calendario"
+    const atcbContainer = document.getElementById('addToCalendarBtn');
+    if (typeof atcb_init === 'function') {
+        const atcbData = {
+            name: event.summary,
+            description: event.description.replace(/<[^>]*>/g, ''),
+            startDate: datePart(event.start_date),
+            endDate: datePart(event.end_date),
+            options: ['Google', 'Outlook.com', 'Apple', 'iCal'],
+            timeZone: 'Europe/Madrid',
+            label: 'Añadir al calendario'
+        };
+        const startTime = formatTime(event.start_date);
+        const endTime = formatTime(event.end_date);
+        if (!isAllDayEvent(startTime, endTime)) {
+            atcbData.startTime = startTime;
+            atcbData.endTime = endTime;
+        }
+        atcbContainer.textContent = JSON.stringify(atcbData);
+        atcbContainer.classList.remove('atcb-initialized');
+        atcb_init();
+    } else {
+        atcbContainer.innerHTML = '';
+        const currentEvent = event; // fallback
         loadCalendarScript(function() {
             CalendarUtils.addToCalendar(currentEvent);
         });
-    };
+    }
 
     document.getElementById('getDirectionsBtn').onclick = function() {
         getDirections(event);

--- a/script.js
+++ b/script.js
@@ -781,32 +781,32 @@ function showEventDetails(event) {
     }
 
     // Preparar botón "Añadir al calendario"
-    const atcbContainer = document.getElementById('addToCalendarBtn');
-    if (typeof atcb_init === 'function') {
-        const atcbData = {
-            name: event.summary,
-            description: event.description.replace(/<[^>]*>/g, ''),
-            startDate: datePart(event.start_date),
-            endDate: datePart(event.end_date),
-            options: ['Google', 'Outlook.com', 'Apple', 'iCal'],
-            timeZone: 'Europe/Madrid',
-            label: 'Añadir al calendario'
+    const addToCalendarBtn = document.getElementById('addToCalendarBtn');
+    const atcbData = {
+        name: event.summary,
+        description: event.description.replace(/<[^>]*>/g, ''),
+        startDate: datePart(event.start_date),
+        endDate: datePart(event.end_date),
+        options: ['Google', 'Outlook.com', 'Apple', 'iCal'],
+        timeZone: 'Europe/Madrid'
+    };
+    const startTime = formatTime(event.start_date);
+    const endTime = formatTime(event.end_date);
+    if (!isAllDayEvent(startTime, endTime)) {
+        atcbData.startTime = startTime;
+        atcbData.endTime = endTime;
+    }
+    if (typeof atcb_action === 'function') {
+        addToCalendarBtn.onclick = function() {
+            atcb_action(atcbData, addToCalendarBtn);
         };
-        const startTime = formatTime(event.start_date);
-        const endTime = formatTime(event.end_date);
-        if (!isAllDayEvent(startTime, endTime)) {
-            atcbData.startTime = startTime;
-            atcbData.endTime = endTime;
-        }
-        atcbContainer.textContent = JSON.stringify(atcbData);
-        atcbContainer.classList.remove('atcb-initialized');
-        atcb_init();
     } else {
-        atcbContainer.innerHTML = '';
-        const currentEvent = event; // fallback
-        loadCalendarScript(function() {
-            CalendarUtils.addToCalendar(currentEvent);
-        });
+        addToCalendarBtn.onclick = function() {
+            const currentEvent = event; // fallback
+            loadCalendarScript(function() {
+                CalendarUtils.addToCalendar(currentEvent);
+            });
+        };
     }
 
     document.getElementById('getDirectionsBtn').onclick = function() {


### PR DESCRIPTION
## Summary
- include `add-to-calendar-button` CSS/JS
- replace the calendar modal button with an `atcb` container
- build event details for the library in `showEventDetails`
- use library to render calendar dropdown or fall back to ICS generation